### PR TITLE
Fail message types can now use Stderr

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - exhaustive
     - gocritic
@@ -17,7 +16,6 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 linters-settings:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
-	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
+	golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,13 @@ github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69Y
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
@@ -16,3 +20,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 h1:AzgQNqF+FKwyQ5LbVrVqOcuuFB67N47F9+htZYH0wFM=
+golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/msg.go
+++ b/msg.go
@@ -1,3 +1,14 @@
+// Package msg is a simple, easy to use console printing toolkit for Go CLIs rendering pretty
+// formatted output with colours and symbols specific to the particular message type:
+//
+//   - Info: For general user information and progress updates
+//   - Title: Separation between sections of output
+//   - Warn: User warnings
+//   - Good: Report success
+//   - Fail: Report failure (defaults to Stderr)
+//
+// The symbols and colours used all have sensible defaults but are completely configurable so you
+// can tweak the output however you like!
 package msg
 
 import (

--- a/msg.go
+++ b/msg.go
@@ -92,7 +92,7 @@ func (p *Printer) Title(text string) {
 }
 
 // Titlef prints a formatted warning message.
-func (p *Printer) Titlef(format string, a ...interface{}) {
+func (p *Printer) Titlef(format string, a ...any) {
 	text := fmt.Sprintf(format, a...)
 	p.Title(text)
 }
@@ -112,7 +112,7 @@ func (p *Printer) Stitle(text string) string {
 }
 
 // Stitlef returns a formatted title string, stripped of all leading/trailing whitespace.
-func (p *Printer) Stitlef(format string, a ...interface{}) string {
+func (p *Printer) Stitlef(format string, a ...any) string {
 	text := fmt.Sprintf(format, a...)
 	return p.Stitle(text)
 }
@@ -128,7 +128,7 @@ func (p *Printer) Warn(text string) {
 }
 
 // Warnf prints a formatted warning message.
-func (p *Printer) Warnf(format string, a ...interface{}) {
+func (p *Printer) Warnf(format string, a ...any) {
 	text := fmt.Sprintf(format, a...)
 	p.Warn(text)
 }
@@ -144,7 +144,7 @@ func (p *Printer) Swarn(text string) string {
 }
 
 // Swarnf returns a formatted warning string.
-func (p *Printer) Swarnf(format string, a ...interface{}) string {
+func (p *Printer) Swarnf(format string, a ...any) string {
 	text := fmt.Sprintf(format, a...)
 	return p.Swarn(text)
 }
@@ -163,7 +163,7 @@ func (p *Printer) Fail(text string) {
 }
 
 // Failf prints a formatted error message to Stderr.
-func (p *Printer) Failf(format string, a ...interface{}) {
+func (p *Printer) Failf(format string, a ...any) {
 	text := fmt.Sprintf(format, a...)
 	p.Fail(text)
 }
@@ -182,7 +182,7 @@ func (p *Printer) Sfail(text string) string {
 }
 
 // Sfailf returns a formatted error string.
-func (p *Printer) Sfailf(format string, a ...interface{}) string {
+func (p *Printer) Sfailf(format string, a ...any) string {
 	text := fmt.Sprintf(format, a...)
 	return p.Sfail(text)
 }
@@ -198,7 +198,7 @@ func (p *Printer) Good(text string) {
 }
 
 // Goodf prints a formatted success message.
-func (p *Printer) Goodf(format string, a ...interface{}) {
+func (p *Printer) Goodf(format string, a ...any) {
 	text := fmt.Sprintf(format, a...)
 	p.Good(text)
 }
@@ -214,7 +214,7 @@ func (p *Printer) Sgood(text string) string {
 }
 
 // Sgoodf returns a formatted success string.
-func (p *Printer) Sgoodf(format string, a ...interface{}) string {
+func (p *Printer) Sgoodf(format string, a ...any) string {
 	text := fmt.Sprintf(format, a...)
 	return p.Sgood(text)
 }
@@ -230,7 +230,7 @@ func (p *Printer) Info(text string) {
 }
 
 // Infof prints a formatted information message.
-func (p *Printer) Infof(format string, a ...interface{}) {
+func (p *Printer) Infof(format string, a ...any) {
 	text := fmt.Sprintf(format, a...)
 	p.Info(text)
 }
@@ -246,7 +246,7 @@ func (p *Printer) Sinfo(text string) string {
 }
 
 // Sinfof returns a formatted info string.
-func (p *Printer) Sinfof(format string, a ...interface{}) string {
+func (p *Printer) Sinfof(format string, a ...any) string {
 	text := fmt.Sprintf(format, a...)
 	return p.Sinfo(text)
 }
@@ -260,7 +260,7 @@ func (p *Printer) Text(text string) {
 // Textf prints a formatted normal message
 // a newline is automatically appended to the end of 'format' so
 // you don't have to.
-func (p *Printer) Textf(format string, a ...interface{}) {
+func (p *Printer) Textf(format string, a ...any) {
 	fmt.Fprintf(p.Stdout, format+"\n", a...)
 }
 
@@ -270,7 +270,7 @@ func (p *Printer) Stext(text string) string {
 }
 
 // Stextf returns a normal, non coloured formatted string.
-func (p *Printer) Stextf(format string, a ...interface{}) string {
+func (p *Printer) Stextf(format string, a ...any) string {
 	return fmt.Sprintf(format, a...)
 }
 
@@ -284,7 +284,7 @@ func Title(text string) {
 }
 
 // Titlef prints a formatted Title message using the default symbols and colors.
-func Titlef(format string, a ...interface{}) {
+func Titlef(format string, a ...any) {
 	p := Default()
 	p.Titlef(format, a...)
 }
@@ -296,7 +296,7 @@ func Stitle(text string) string {
 }
 
 // Stitlef returns a formatted Title string using the default symbols and colors.
-func Stitlef(format string, a ...interface{}) string {
+func Stitlef(format string, a ...any) string {
 	p := Default()
 	return p.Stitlef(format, a...)
 }
@@ -308,7 +308,7 @@ func Warn(text string) {
 }
 
 // Warnf prints a formatted warning message using the default symbols and colors.
-func Warnf(format string, a ...interface{}) {
+func Warnf(format string, a ...any) {
 	p := Default()
 	p.Warnf(format, a...)
 }
@@ -320,7 +320,7 @@ func Swarn(text string) string {
 }
 
 // Swarnf returns a formatted warning string using the default symbols and colors.
-func Swarnf(format string, a ...interface{}) string {
+func Swarnf(format string, a ...any) string {
 	p := Default()
 	return p.Swarnf(format, a...)
 }
@@ -332,7 +332,7 @@ func Fail(text string) {
 }
 
 // Failf prints a formatted error message using the default symbols and colors.
-func Failf(format string, a ...interface{}) {
+func Failf(format string, a ...any) {
 	p := Default()
 	p.Failf(format, a...)
 }
@@ -344,7 +344,7 @@ func Sfail(text string) string {
 }
 
 // Sfailf returns a formatted error message using the default symbols and colors.
-func Sfailf(format string, a ...interface{}) string {
+func Sfailf(format string, a ...any) string {
 	p := Default()
 	return p.Sfailf(format, a...)
 }
@@ -356,7 +356,7 @@ func Good(text string) {
 }
 
 // Goodf prints a formatted success message using the default symbols and colors.
-func Goodf(format string, a ...interface{}) {
+func Goodf(format string, a ...any) {
 	p := Default()
 	p.Goodf(format, a...)
 }
@@ -368,7 +368,7 @@ func Sgood(text string) string {
 }
 
 // Sgoodf returns a formatted success message using the default symbols and colors.
-func Sgoodf(format string, a ...interface{}) string {
+func Sgoodf(format string, a ...any) string {
 	p := Default()
 	return p.Sgoodf(format, a...)
 }
@@ -380,7 +380,7 @@ func Info(text string) {
 }
 
 // Infof prints a formatted information message using the default symbols and colors.
-func Infof(format string, a ...interface{}) {
+func Infof(format string, a ...any) {
 	p := Default()
 	p.Infof(format, a...)
 }
@@ -392,7 +392,7 @@ func Sinfo(text string) string {
 }
 
 // Sinfof returns a formatted information message using the default symbols and colors.
-func Sinfof(format string, a ...interface{}) string {
+func Sinfof(format string, a ...any) string {
 	p := Default()
 	return p.Sinfof(format, a...)
 }
@@ -404,7 +404,7 @@ func Text(text string) {
 }
 
 // Textf prints a formatted normal, uncoloured message.
-func Textf(format string, a ...interface{}) {
+func Textf(format string, a ...any) {
 	p := Default()
 	p.Textf(format, a...)
 }
@@ -416,7 +416,7 @@ func Stext(text string) string {
 }
 
 // Stextf returns a formatted normal, uncoloured message.
-func Stextf(format string, a ...interface{}) string {
+func Stextf(format string, a ...any) string {
 	p := Default()
 	return p.Stextf(format, a...)
 }

--- a/msg.go
+++ b/msg.go
@@ -28,7 +28,8 @@ const (
 // Printer is the primary construct in msg, it allows you to configure the colors
 // and symbols used for each of the printing methods attached to it.
 type Printer struct {
-	Out         io.Writer       // Stdout
+	Stdout      io.Writer       // Stdout
+	Stderr      io.Writer       // Stderr
 	SymbolInfo  string          // Symbol for the Info output
 	SymbolTitle string          // Symbol for the Title output
 	SymbolWarn  string          // Symbol for the Warn output
@@ -55,7 +56,8 @@ func Default() *Printer {
 		ColorWarn:   defaultWarnColor,
 		ColorFail:   defaultFailColor,
 		ColorGood:   defaultGoodColor,
-		Out:         os.Stdout,
+		Stdout:      os.Stdout,
+		Stderr:      os.Stderr,
 	}
 }
 
@@ -75,7 +77,7 @@ func (p *Printer) Title(text string) {
 	} else {
 		text = fmt.Sprintf("\n%s\n\n", text)
 	}
-	title.Fprint(p.Out, text)
+	title.Fprint(p.Stdout, text)
 }
 
 // Titlef prints a formatted warning message.
@@ -111,7 +113,7 @@ func (p *Printer) Warn(text string) {
 	if p.SymbolWarn != "" {
 		text = fmt.Sprintf("%s  %s", p.SymbolWarn, text)
 	}
-	warn.Fprintln(p.Out, text)
+	warn.Fprintln(p.Stdout, text)
 }
 
 // Warnf prints a formatted warning message.
@@ -136,7 +138,7 @@ func (p *Printer) Swarnf(format string, a ...interface{}) string {
 	return p.Swarn(text)
 }
 
-// Fail prints an error message.
+// Fail prints an error message to Stderr.
 func (p *Printer) Fail(text string) {
 	failStyle := color.New(p.ColorFail).Add(color.Bold)
 	messageStyle := color.New(color.FgHiWhite, color.Bold)
@@ -146,10 +148,10 @@ func (p *Printer) Fail(text string) {
 	if p.SymbolFail != "" {
 		text = fmt.Sprintf("%s  %s", failStyle.Sprint(p.SymbolFail), text)
 	}
-	fmt.Fprintln(p.Out, text)
+	fmt.Fprintln(p.Stderr, text)
 }
 
-// Failf prints a formatted error message.
+// Failf prints a formatted error message to Stderr.
 func (p *Printer) Failf(format string, a ...interface{}) {
 	text := fmt.Sprintf(format, a...)
 	p.Fail(text)
@@ -181,7 +183,7 @@ func (p *Printer) Good(text string) {
 	if p.SymbolGood != "" {
 		text = fmt.Sprintf("%s  %s", p.SymbolGood, text)
 	}
-	good.Fprintln(p.Out, text)
+	good.Fprintln(p.Stdout, text)
 }
 
 // Goodf prints a formatted success message.
@@ -213,7 +215,7 @@ func (p *Printer) Info(text string) {
 	if p.SymbolInfo != "" {
 		text = fmt.Sprintf("%s  %s", p.SymbolInfo, text)
 	}
-	info.Fprintln(p.Out, text)
+	info.Fprintln(p.Stdout, text)
 }
 
 // Infof prints a formatted information message.
@@ -241,14 +243,14 @@ func (p *Printer) Sinfof(format string, a ...interface{}) string {
 // Text prints a normal, uncoloured message
 // you could argue we don't need this as all is does is call fmt.Fprintln but we're here now.
 func (p *Printer) Text(text string) {
-	fmt.Fprintln(p.Out, text)
+	fmt.Fprintln(p.Stdout, text)
 }
 
 // Textf prints a formatted normal message
 // a newline is automatically appended to the end of 'format' so
 // you don't have to.
 func (p *Printer) Textf(format string, a ...interface{}) {
-	fmt.Fprintf(p.Out, format+"\n", a...)
+	fmt.Fprintf(p.Stdout, format+"\n", a...)
 }
 
 // Stext is like Text but returns a string rather than printing it.


### PR DESCRIPTION
- Make Fail methods write to stderr
- Add package level doc
- gofmt -r 'interface{} -> any' -w *.go

<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
This PR adds a `Stderr` field to the `Printer` struct and configures all Fail type messages
to write to this configured `Stderr`.

This enables programs using `msg` to output errors to better follow Unix principles
and report error conditions to stderr.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
